### PR TITLE
Add genesis_tesla interface for openpilot HUD

### DIFF
--- a/genesis_tesla/README.md
+++ b/genesis_tesla/README.md
@@ -1,0 +1,6 @@
+# genesis_tesla
+
+Small interface to show openpilot HUD information.
+
+Use `user_menu.py` to run a curses based UI that subscribes to openpilot's
+`carControl` and `controlsState` messages.

--- a/genesis_tesla/__init__.py
+++ b/genesis_tesla/__init__.py
@@ -1,0 +1,5 @@
+"""Genesis Tesla integration helpers."""
+
+from .openpilot_interface import OpenpilotInterface, HUDData
+
+__all__ = ["OpenpilotInterface", "HUDData"]

--- a/genesis_tesla/openpilot_interface.py
+++ b/genesis_tesla/openpilot_interface.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Interface for reading openpilot HUDControl data."""
+
+import time
+from dataclasses import dataclass
+from typing import Dict
+
+from cereal import messaging, car
+
+@dataclass
+class HUDData:
+    set_speed: float
+    left_lane_visible: bool
+    right_lane_visible: bool
+    lead_distance_bars: int
+    visual_alert: int
+    audible_alert: int
+
+class OpenpilotInterface:
+    """Subscribe to openpilot messaging and expose HUDControl state."""
+
+    def __init__(self) -> None:
+        # Subscribe to carControl and controlsState like openpilot's UI
+        self.sm = messaging.SubMaster(['carControl', 'controlsState'])
+
+    def update(self) -> HUDData:
+        """Poll for new messages and return HUD data."""
+        self.sm.update(0)
+        cc = self.sm['carControl']
+        hud = cc.hudControl
+        return HUDData(
+            set_speed=float(hud.setSpeed),
+            left_lane_visible=bool(hud.leftLaneVisible),
+            right_lane_visible=bool(hud.rightLaneVisible),
+            lead_distance_bars=int(hud.leadDistanceBars),
+            visual_alert=int(hud.visualAlert),
+            audible_alert=int(hud.audibleAlert),
+        )

--- a/genesis_tesla/pyproject.toml
+++ b/genesis_tesla/pyproject.toml
@@ -1,0 +1,7 @@
+[project]
+name = "genesis_tesla"
+version = "0.1.0"
+requires-python = ">=3.11"
+
+[project.dependencies]
+cereal = {path = "../cereal"}

--- a/genesis_tesla/user_menu.py
+++ b/genesis_tesla/user_menu.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""Simple text UI showing data from openpilot."""
+
+import curses
+import time
+
+from .openpilot_interface import OpenpilotInterface
+
+UPDATE_DT = 0.05  # 20 Hz
+
+
+def draw(stdscr, iface: OpenpilotInterface) -> None:
+    curses.curs_set(0)
+    stdscr.nodelay(True)
+
+    while True:
+        data = iface.update()
+        stdscr.erase()
+        stdscr.addstr(0, 0, f"Set speed: {data.set_speed:.1f}")
+        stdscr.addstr(1, 0, f"Lanes: L={data.left_lane_visible} R={data.right_lane_visible}")
+        stdscr.addstr(2, 0, f"Lead distance bars: {data.lead_distance_bars}")
+        stdscr.addstr(3, 0, f"Visual alert: {data.visual_alert}")
+        stdscr.addstr(4, 0, f"Audible alert: {data.audible_alert}")
+        stdscr.refresh()
+        time.sleep(UPDATE_DT)
+
+
+def main() -> None:
+    iface = OpenpilotInterface()
+    curses.wrapper(draw, iface)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION

- add a new `genesis_tesla` package
- implement `openpilot_interface.py` for reading `carControl`/`controlsState`
- expose a simple curses menu displaying set speed, lane markers and alerts
- document basic usage and pyproject for dependency on openpilot's cereal

